### PR TITLE
Fix parameter order bug

### DIFF
--- a/app/src/main/java/com/example/lezh1k/sensordatacollector/MainActivity.java
+++ b/app/src/main/java/com/example/lezh1k/sensordatacollector/MainActivity.java
@@ -197,8 +197,8 @@ public class MainActivity extends AppCompatActivity implements LocationServiceIn
                 KalmanLocationService.Settings settings =
                         new KalmanLocationService.Settings(
                                 Utils.ACCELEROMETER_DEFAULT_DEVIATION,
-                                Integer.parseInt(mSharedPref.getString("pref_gps_min_time", "")),
                                 Integer.parseInt(mSharedPref.getString("pref_gps_min_distance", "")),
+                                Integer.parseInt(mSharedPref.getString("pref_gps_min_time", "")),
                                 Integer.parseInt(mSharedPref.getString("pref_position_min_time", "")),
                                 Integer.parseInt(mSharedPref.getString("pref_geohash_precision", "")),
                                 Integer.parseInt(mSharedPref.getString("pref_geohash_min_point", "")),


### PR DESCRIPTION
Gps time parameter order is in MainActivity is swapped with distance, causing those who tamper with settings might get unexpected results (ex. Map not updating when setting gps update time to 2000ms, which instead causes the gps to _not_ update if the distance is not over 2000 meters)