### PR TITLE
Add prooject to afterEvaluate

### DIFF
--- a/madlocationmanager/build.gradle
+++ b/madlocationmanager/build.gradle
@@ -71,7 +71,7 @@ task javadocJar(type: Jar, dependsOn: androidJavadocs) {
     from androidJavadocs.destinationDir
 }
 
-afterEvaluate {
+project.afterEvaluate {
     publishing {
         publications {
             mavenPublication(MavenPublication) {


### PR DESCRIPTION
`afterEvaluate {` fails for most recent gradle plugin