### PR TITLE
add default values for bintrayUser and bintrayKey

### DIFF
--- a/madlocationmanager/build.gradle
+++ b/madlocationmanager/build.gradle
@@ -116,8 +116,8 @@ bintray {
     dryRun = false
     publish = true
     override = true
-    user = System.getenv('BINTRAY_USER') ?: bintrayUser
-    key = System.getenv('BINTRAY_KEY') ?: bintrayKey
+    user = System.getenv('BINTRAY_USER') ?: (project.hasProperty('bintrayUser') ? project.property('bintrayUser') : '')
+    key = System.getenv('BINTRAY_KEY') ?: (project.hasProperty('bintrayKey') ? project.property('bintrayKey') : '')
     publications = ['mavenPublication']
 
     pkg {


### PR DESCRIPTION
Having not these gradle properties set (that is for 99.99% of users) causes gradle sync to fail. 

This is a fix for https://github.com/maddevsio/mad-location-manager/pull/89#issuecomment-727291599