### PR TITLE
Fixed one of issues mentioned in #103: crash due to mismatching matrix dimensions

### DIFF
--- a/app/src/main/java/com/example/lezh1k/sensordatacollector/MainActivity.java
+++ b/app/src/main/java/com/example/lezh1k/sensordatacollector/MainActivity.java
@@ -206,6 +206,7 @@ public class MainActivity extends AppCompatActivity implements LocationServiceIn
                                 this,
                                 false,
                                 true,
+                                true,
                                 Utils.DEFAULT_VEL_FACTOR,
                                 Utils.DEFAULT_POS_FACTOR
                         );

--- a/madlocationmanager/src/main/java/mad/location/manager/lib/Filters/GPSAccKalmanFilter.java
+++ b/madlocationmanager/src/main/java/mad/location/manager/lib/Filters/GPSAccKalmanFilter.java
@@ -142,7 +142,11 @@ public class GPSAccKalmanFilter {
         m_predictCount = 0;
         m_timeStampMsUpdate = timeStamp;
         rebuildR(posDev, velErr);
-        m_kf.Zk.setData(x, y, xVel, yVel);
+        if (m_useGpsSpeed) {
+            m_kf.Zk.setData(x, y, xVel, yVel);
+        } else {
+            m_kf.Zk.setData(x, y);
+        }
         m_kf.update();
     }
 

--- a/madlocationmanager/src/main/java/mad/location/manager/lib/Services/KalmanLocationService.java
+++ b/madlocationmanager/src/main/java/mad/location/manager/lib/Services/KalmanLocationService.java
@@ -55,6 +55,7 @@ public class KalmanLocationService extends Service
         private ILogger logger;
         private boolean filterMockGpsCoordinates;
         private boolean onlyGpsSensor;
+        private boolean useGpsSpeed;
 
         private double mVelFactor;
         private double mPosFactor;
@@ -70,6 +71,7 @@ public class KalmanLocationService extends Service
                         ILogger logger,
                         boolean filterMockGpsCoordinates,
                         boolean onlyGpsSensor,
+                        boolean useGpsSpeed,
                         double velFactor,
                         double posFactor) {
             this.accelerationDeviation = accelerationDeviation;
@@ -82,6 +84,7 @@ public class KalmanLocationService extends Service
             this.logger = logger;
             this.filterMockGpsCoordinates = filterMockGpsCoordinates;
             this.onlyGpsSensor = onlyGpsSensor;
+            this.useGpsSpeed = useGpsSpeed;
             this.mVelFactor = velFactor;
             this.mPosFactor = posFactor;
         }
@@ -211,6 +214,7 @@ public class KalmanLocationService extends Service
                     null,
                     true,
                     true,
+                    false,
                     Utils.DEFAULT_VEL_FACTOR,
                     Utils.DEFAULT_POS_FACTOR
             );
@@ -611,7 +615,7 @@ public class KalmanLocationService extends Service
                     Utils.LogMessageType.KALMAN_ALLOC.ordinal(),
                     timeStamp, x, y, speed, course, m_settings.accelerationDeviation, posDev);
             m_kalmanFilter = new GPSAccKalmanFilter(
-                    false, //todo move to settings
+                    m_settings.useGpsSpeed,
                     Coordinates.longitudeToMeters(x),
                     Coordinates.latitudeToMeters(y),
                     xVel,


### PR DESCRIPTION
Implemented one TODO: moved useGpsSpeed to settings to properly set this up.

Fixed issue when useGpsSpeed is false and update method causes assertion error, as it passes 4 values and matrix expects only 2.