### PR TITLE
Fix NoSuchMethodError on API < 30

### DIFF
--- a/madlocationmanager/src/main/java/mad/location/manager/lib/locationProviders/GPSLocationProvider.java
+++ b/madlocationmanager/src/main/java/mad/location/manager/lib/locationProviders/GPSLocationProvider.java
@@ -100,7 +100,7 @@ public class GPSLocationProvider implements LocationListener {
     @RequiresPermission(ACCESS_FINE_LOCATION)
     public void startLocationUpdates(Settings m_settings, HandlerThread thread) {
         m_locationManager.removeGpsStatusListener(gpsListener);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             m_locationManager.registerGnssStatusCallback(executorService, gnssStatus);
         } else {
             m_locationManager.addGpsStatusListener(gpsListener);


### PR DESCRIPTION
`LocationManager.registerGnssStatusCallback` method is only available on API 30 and later.

If not fixed, there will be a crash on service start:
```
 Caused by: java.lang.NoSuchMethodError: No virtual method registerGnssStatusCallback(Ljava/util/concurrent/Executor;Landroid/location/GnssStatus$Callback;)Z in class Landroid/location/LocationManager; or its super classes (declaration of 'android.location.LocationManager' appears in /system/framework/framework.jar)
    at mad.location.manager.lib.locationProviders.GPSLocationProvider.startLocationUpdates(GPSLocationProvider.java:104)
    at mad.location.manager.lib.Services.KalmanLocationService.start(KalmanLocationService.java:423)
    at com.example.lezh1k.sensordatacollector.MainActivity.lambda$set_isLogging$0$MainActivity(MainActivity.java:229)
    at com.example.lezh1k.sensordatacollector.-$$Lambda$MainActivity$xUfrdjyKquT9zz-rkrO7mpaulHY.onCall(Unknown Source:6)
    at mad.location.manager.lib.Services.ServicesHelper.getLocationService(ServicesHelper.java:95)
    at com.example.lezh1k.sensordatacollector.MainActivity.set_isLogging(MainActivity.java:205)
    at com.example.lezh1k.sensordatacollector.MainActivity.btnStartStop_click(MainActivity.java:278)
```